### PR TITLE
Run all tests when the enter key is pressed

### DIFF
--- a/src/metosin/boot_alt_test.clj
+++ b/src/metosin/boot_alt_test.clj
@@ -18,10 +18,11 @@
   Default reporter is eftest.report.progress/report. Some alternatives are:
   - eftest.report.pretty/report (no progress bar)
   - clojure.test/report"
-  [m test-matcher VAL regex "Regex used to select test namespaces"
-   p parallel         bool  "Run tests parallel"
-   r report       VAL sym   "Reporting function"
-   f fail             bool  "Throw on failure (use on CI)"]
+  [m test-matcher    VAL regex "Regex used to select test namespaces"
+   p parallel            bool  "Run tests parallel"
+   r report          VAL sym   "Reporting function"
+   f fail                bool  "Throw on failure (use on CI)"
+   e enter-runs-all      bool  "Pressing the enter key will run all tests"]
   (let [p (-> (core/get-env)
               (update-in [:dependencies] into deps)
               pod/make-pod
@@ -31,6 +32,8 @@
                                :parallel? parallel
                                :report-sym report}))]
     (fn [handler]
+      (if enter-runs-all
+        (pod/with-call-in @p (metosin.boot-alt-test.impl/enter-key-listener opts)))
       (fn [fileset]
         (let [summary (pod/with-call-in @p (metosin.boot-alt-test.impl/run ~opts))]
           (if (> (+ (:fail summary 0) (:error summary 0)) 0)


### PR DESCRIPTION
A developer should be able to trigger a full test run arbitrarily under continuous testing mode. 

This applies mostly to situations where tests where ran for a subset of the target namespaces that where subject to change and we want to check that these changes didn't brake something outside of the code covered by the restricted run. 

This pull request adds an option to the `alt-test` task that enables this behaviour.

Both ruby's [guard-rspec](https://github.com/guard/guard-rspec) and clojure's [lein-test-refresh](https://github.com/jakemcc/lein-test-refresh) (referenced at #3) provide this feature.
