### PR TITLE
Set java.awt.headless property to true to disable popup on OS X.

### DIFF
--- a/src/metosin/boot_alt_test.clj
+++ b/src/metosin/boot_alt_test.clj
@@ -31,6 +31,7 @@
                                :parallel? parallel
                                :report-sym report}))]
     (fn [handler]
+      (System/setProperty "java.awt.headless" "true")
       (pod/with-call-in @p (metosin.boot-alt-test.impl/enter-key-listener opts))
       (fn [fileset]
         (let [summary (pod/with-call-in @p (metosin.boot-alt-test.impl/run ~opts))]


### PR DESCRIPTION
Since 0.1.1 uses an AWT KeyEvent, alt-test creates an icon in the OS X dock and steals focus. This PR sets the java.awt.headless property during test runs.
