### PR TITLE
Link to Boot and Leiningen from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Formerly known as Boot-alt-test
 
-Fast Clojure.test runner for Boot and Lein.
+Fast Clojure.test runner for [Boot](http://boot-clj.com/) and [Leiningen](https://leiningen.org/).
 
 ## Features
 


### PR DESCRIPTION
Noticed you mention Leiningen after the rename so fixed the name, and figured I'd link to both project's homepages while making the edit.

Out of interest, was the rename done because you're targeting Leiningen too now?