### PR TITLE
Fix file watch stoppage as a result of compile failures

### DIFF
--- a/src/leiningen/bat_test.clj
+++ b/src/leiningen/bat_test.clj
@@ -51,7 +51,10 @@
               (watchtower.core/file-filter (watchtower.core/extensions :clj :cljc))
               (watchtower.core/on-change (fn [~'_]
                                            (println)
-                                           (metosin.bat-test.impl/run ~opts)))))
+                                           (try
+                                             (metosin.bat-test.impl/run ~opts)
+                                             (catch Exception e#
+                                               (println e#)))))))
         `(let [summary# (metosin.bat-test.impl/run ~opts)
                exit-code# (+ (:fail summary# 0) (:error summary# 0))]
            (if ~(= :leiningen (:eval-in project))


### PR DESCRIPTION
This adds a simple try catch block to continue watching files
and retry compilation after changes as suggested by @miikka.

This fixes issue #34