### PR TITLE
Update eftest to 0.5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Fast Clojure.test runner for [Boot](http://boot-clj.com/) and [Leiningen](https:
     - Can optionally run tests parallel
     - Can capture output and display the output just for the failing tests (`:capture-output?`, enabled by default)
     - Can be configured to stop running tests after the first failure (`:fail-fast?`)
+    - Can run tests in deterministically random order (`:randomize-seed`, defaults to 0)
 - Easy way to setup and combine eftest reporters:
     - Built-in reporters can be referred by keywords `:pretty`, `:progress` and `:junit`
     - Reporter can be map with `:type` (referring to reporter fn) and option `:output-to`

--- a/build.boot
+++ b/build.boot
@@ -3,7 +3,7 @@
 (set-env!
   :resource-paths #{"src"}
   :dependencies   '[[org.clojure/clojure "1.10.0" :scope "provided"]
-                    [eftest "0.5.7" :scope "test"]
+                    [eftest "0.5.9" :scope "test"]
                     [cloverage "1.1.1" :scope "test"]
                     [org.clojure/tools.namespace "0.3.0-alpha4" :scope "test"]])
 

--- a/src/leiningen/bat_test.clj
+++ b/src/leiningen/bat_test.clj
@@ -9,7 +9,7 @@
             [metosin.bat-test.version :refer [+version+]]))
 
 (def profile {:dependencies [['metosin/bat-test +version+]
-                             ['eftest "0.5.4"]
+                             ['eftest "0.5.9"]
                              ['org.clojure/tools.namespace "0.3.0-alpha4"]
                              ['cloverage "1.0.13"]
                              ['watchtower "0.1.1"]]})

--- a/src/metosin/bat_test.clj
+++ b/src/metosin/bat_test.clj
@@ -6,7 +6,7 @@
             [metosin.bat-test.version :refer [+version+]]))
 
 (def ^:private deps
-  [['eftest "0.5.4"]
+  [['eftest "0.5.9"]
    ['metosin/bat-test +version+]
    ['cloverage "1.0.13"]
    ['org.clojure/tools.namespace "0.3.0-alpha4"]])


### PR DESCRIPTION
eftest 0.5.9 was released recently and a new option `:randomize-seed` was added. This PR allows to use this option in bat-test.