### PR TITLE
Add :rate to control watchtower file change scanning rate

### DIFF
--- a/src/leiningen/bat_test.clj
+++ b/src/leiningen/bat_test.clj
@@ -46,7 +46,7 @@
            (metosin.bat-test.impl/enter-key-listener ~opts)
            @(watchtower.core/watcher
               ~watch-directories
-              (watchtower.core/rate 100)
+              (watchtower.core/rate (:rate ~opts 100))
               (watchtower.core/file-filter watchtower.core/ignore-dotfiles)
               (watchtower.core/file-filter (watchtower.core/extensions :clj :cljc))
               (watchtower.core/on-change (fn [~'_]
@@ -103,6 +103,7 @@ Available options:
 :on-end          Function to be called after running tests
 :cloverage-opts  Cloverage options
 :notify-command  String or vector describing a command to run after tests
+:rate            Timeout for file change scanning
 
 Also supports Lein test selectors, check `lein test help` for more information.
 

--- a/src/metosin/bat_test/impl.clj
+++ b/src/metosin/bat_test/impl.clj
@@ -155,7 +155,6 @@
 
     ((resolve-hook on-start))
     (util/info "Testing: %s\n" (string/join ", " test-namespaces))
-
     (maybe-run-cloverage
        (fn []
          (runner/run-tests
@@ -163,7 +162,7 @@
                 (selectors-match selectors)
                 (filter (resolve-hook (:filter opts))))
            (-> opts
-               (dissoc :parallel? :on-start :on-end :filter :test-matcher :selectors)
+               (dissoc :parallel? :on-start :on-end :filter :test-matcher :selectors :rate)
                (assoc :multithread? parallel?
                       :report (resolve-reporter report)))))
        opts


### PR DESCRIPTION
This is just a suggestion to make the watchtower rate configurable. The default rate causes full cpu burn on my machine on a project with 500ish files. That eats up laptop battery unnecessarily.

A more sensible approach would be to utilize some sane file watcher, one that uses `inotify` or similar. Maybe Hawk, clojure-watch or something?

signed-off-by: Tommi Kyntölä <tommi.kyntola@gmail.com>